### PR TITLE
remove import Compat from src/GenericSVD.jl

### DIFF
--- a/src/GenericSVD.jl
+++ b/src/GenericSVD.jl
@@ -1,7 +1,6 @@
 __precompile__(true)
 module GenericSVD
 
-import Compat: view
 import Base: SVD
 
 include("utils.jl")


### PR DESCRIPTION
no longer in REQUIRE, shouldn't be imported in src

Quaternions is in test/REQUIRE and happens to currently depend on Compat,
which is why this wasn't visible on Travis.