### PR TITLE
remove unnecessary pirate methods

### DIFF
--- a/src/GenericSVD.jl
+++ b/src/GenericSVD.jl
@@ -190,7 +190,7 @@ function svd_zerodiag_row!(U,B,n₁,n₂)
         dᵢ = B.dv[i]
 
         G,r = givens(dᵢ,e,i,n₁)
-        rmul!(U,adjoint(G))
+        (U === nothing) || rmul!(U,adjoint(G))
         B.dv[i] = r # -G.s*e + G.c*dᵢ
 
         if i < n₂
@@ -219,7 +219,7 @@ function svd_zerodiag_col!(B,Vt,n₁,n₂)
         dᵢ = B.dv[i]
 
         G,r = givens(dᵢ,e,i,n₂)
-        lmul!(G,Vt)
+        (Vt === nothing) || lmul!(G,Vt)
 
         B.dv[i] = r # G.c*dᵢ + G.s*e
 
@@ -249,7 +249,7 @@ function svd_gk!(B::Bidiagonal{T},U,Vt,n₁,n₂,shift) where T <: Real
         d₂′ = B.dv[n₁+1]
 
         G, r = givens(d₁′ - abs2(shift)/d₁′, e₁′, n₁, n₁+1)
-        lmul!(G,Vt)
+        (Vt === nothing) || lmul!(G,Vt)
 
         #  [d₁,e₁] = [d₁′,e₁′] * G'
         #  [b ,d₂]   [0  ,d₂′]
@@ -268,7 +268,7 @@ function svd_gk!(B::Bidiagonal{T},U,Vt,n₁,n₂,shift) where T <: Real
             e₂ = B.ev[i+1]
 
             G, r = givens(d₁, b, i, i+1)
-            rmul!(U,adjoint(G))
+            (U === nothing) || rmul!(U,adjoint(G))
 
             B.dv[i] =  r # G.c*d₁ + G.s*b
 
@@ -285,7 +285,7 @@ function svd_gk!(B::Bidiagonal{T},U,Vt,n₁,n₂,shift) where T <: Real
             d₃′ = B.dv[i+2]
 
             G, r = givens(e₁′, b′, i+1, i+2)
-            lmul!(G, Vt)
+            (Vt === nothing) || lmul!(G, Vt)
 
             B.ev[i] = r # e₁′*G.c + b′*G.s
 
@@ -300,7 +300,7 @@ function svd_gk!(B::Bidiagonal{T},U,Vt,n₁,n₂,shift) where T <: Real
         #  [0 ,.]       [b ,d₂]
 
         G, r = givens(d₁,b,n₂-1,n₂)
-        rmul!(U, adjoint(G))
+        (U === nothing) || rmul!(U, adjoint(G))
 
         B.dv[n₂-1] =  r # G.c*d₁ + G.s*b
 

--- a/src/bidiagonalize.jl
+++ b/src/bidiagonalize.jl
@@ -35,7 +35,7 @@ function bidiagonalize_tall!(A::Matrix{T},B::Bidiagonal) where T
             conj!(x)
             τi = LinearAlgebra.reflector!(x)
             B.ev[i] = real(A[i,i+1])
-            LinearAlgebra.reflectorApply!(@view(A[i+1:m, i+1:n]), x, τi)
+            rreflectorApply!(@view(A[i+1:m, i+1:n]), x, τi)
             A[i,i+1] = τi
         end
     end
@@ -72,7 +72,7 @@ function unpack(P::PackedUVt{T};full=false) where T
     for i = n-1:-1:1
         τi = A[i,i+1]
         x = @view A[i, i+1:n]
-        reflectorApply!(@view(Vt[i:n, i+1:n]), x, τi')
+        rreflectorApply!(@view(Vt[i:n, i+1:n]), x, τi')
     end
     U,Vt
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,5 @@
-# Avast, LinearAlgebra, prepare to be boarded!
-import LinearAlgebra: reflectorApply!
 
-@inline function reflectorApply!(A::StridedMatrix, x::AbstractVector, τ::Number) # apply conjugate transpose reflector from right.
+@inline function rreflectorApply!(A::StridedMatrix, x::AbstractVector, τ::Number) # apply conjugate transpose reflector from right.
     m, n = size(A)
     if length(x) != n
         throw(DimensionMismatch("reflector must have same length as second dimension of matrix"))
@@ -21,14 +19,3 @@ import LinearAlgebra: reflectorApply!
     end
     return A
 end
-
-
-import LinearAlgebra: lmul!, rmul!
-
-lmul!(G::LinearAlgebra.Givens{T}, ::Nothing) where T = nothing
-
-# This worked for early betas of 0.7:
-# rmul!(::Nothing, Ga::Adjoint{Any,LinearAlgebra.Givens{T}}) where T = nothing
-
-# Now that adjoint of Givens is material:
-rmul!(::Nothing, G::LinearAlgebra.Givens{T}) where T = nothing


### PR DESCRIPTION
I've seen a few complaints about the `Xmul!` overloads, so let's do without them.